### PR TITLE
Updated script to build on Raspberry Pi

### DIFF
--- a/src/main/c/build/linux-arm.sh
+++ b/src/main/c/build/linux-arm.sh
@@ -9,7 +9,7 @@ set -e
 OS="linux"
 ARCH="arm"
 HOST="$ARCH-$OS-gnueabi"
-CFLAGS="-Os"
+CFLAGS="-Os -lrt"
 UDEV_SUPPORT="no"
 
 build


### PR DESCRIPTION
This was a hard one to sort out.

When I used version 1.0 on my Raspberry Pi, my test program didn't even load the native library. Issue #26 is related to this.

Then I cloned and built the 1.2.0 snapshot and then I was getting a segmentation fault in the native lib.

Then I built the native library on my Raspberry Pi, and then started getting the error:

```
java: symbol lookup error: /tmp/usb4java8367010293512881329.tmp/libusb4java.so: undefined symbol: clock_gettime
```

After some research, I found that the flag `-lrt` should be used to link with the real time library (librt). Added the flag to the script, built, packaged and it worked!

So, if you need to run on Raspberry Pi just clone this PR, build on your Raspberry Pi with `./linux-arm.sh`, and then package with `mvn package`. After this, use the packaged jar in your app.

**Keep in mind that I'm using Raspbian**, a "Raspberry" flavored Debian distribution (one of the most used in this device). For other distros, it may work without any modification.

If you need the jar or compiled native, just tell me.
