### PR TITLE
Add javadoc for LIBUSB_ERROR_INVALID_PARAM

### DIFF
--- a/src/main/java/org/usb4java/LibUsb.java
+++ b/src/main/java/org/usb4java/LibUsb.java
@@ -1817,7 +1817,9 @@ public final class LibUsb
      *         {@link #ERROR_TIMEOUT} if the transfer timed out,
      *         {@link #ERROR_PIPE} if the control request was not supported by
      *         the device, {@link #ERROR_NO_DEVICE} if the device has been
-     *         disconnected, another ERROR code on other failures
+     *         disconnected, {@link LIBUSB_ERROR_INVALID_PARAM} if the transfer
+     *         size is larger than the operating system and/or hardware can 
+     *         support. Another ERROR code on other failures
      */
     public static native int controlTransfer(final DeviceHandle handle,
         final byte bmRequestType, final byte bRequest, final short wValue,


### PR DESCRIPTION
The native function controlTransfer return a LIBUSB_ERROR_INVALID_PARAM in case the transfer size is not supported